### PR TITLE
Replace usage of unshift with concat

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -20,19 +20,11 @@ module.exports = function flatten (array) {
       // only process `value` if it has some elements.
       if (value.length > 0) {
 
-        // to provide the `value` array to splice() we need to add the
-        // splice() args to its front.
-        // these args tell it to splice at `i` and delete what's at `i`.
-        value.unshift(i, 1)
-
-        // NOTE:
-        // This is an in-place change; it mutates `array`.
+        // prepend our value with [i,1] to tell splice to
+        // start splicing at `i` and delete the element at `i`.
+        // NOTE: This is an in-place change; it mutates `array`.
         // To avoid this, wrap your array like: flatten([myarray])
-        array.splice.apply(array, value)
-
-        // take (i, 1) back off the `value` front
-        // so it remains "unchanged".
-        value.splice(0, 2)
+        array.splice.apply(array, [i,1].concat(value))
       } else {
         // remove an empty array from `array`
         array.splice(i, 1)


### PR DESCRIPTION
I was able to get a better perf results by using `Array.prototype.concat` to create a new array with the additional args needed, instead of mutating the value being flattened twice with `unshift` and `splice`.

Results:

<img width="467" alt="Screen Shot 2019-11-17 at 12 04 02 AM" src="https://user-images.githubusercontent.com/3886060/69003532-e1efd600-08d1-11ea-9e83-675eb7580efe.png">

I also gave `array.splice.call(array, i,1,...value)` a shot which would transpile to `array.call.apply(array.splice, [array, i, 1].concat(value))` but the benchmark was about the same. 

edit: Tests are passing aside from `verify optimizability -> with empty array`, which wasn't passing originally on master.

